### PR TITLE
Change cljs dependency to provided

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -5,7 +5,7 @@
           :source-paths   #{"test"}
           :exclusions     '[org.clojure/clojurescript]
           :dependencies   '[[org.clojure/clojure "1.8.0"]
-                            [org.clojure/clojurescript "1.9.908"]
+                            [org.clojure/clojurescript "1.9.908" :scope "provided"]
                             [net.cgrand/macrovich "0.2.0"]
 
                             ;; Dev


### PR DESCRIPTION
CLJS users will want to bring their own version (via a build tool or build-time dependency), and clj users will appreciate removing the direct and transitive dependencies that clojurescript pulls in.